### PR TITLE
[FEAT} 사기 위험도 분석 페이지 API 연동

### DIFF
--- a/src/api/axiosConfig.js
+++ b/src/api/axiosConfig.js
@@ -1,0 +1,47 @@
+import axios from 'axios'
+
+// axios 인스턴스 생성
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
+  timeout: 30000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+// 요청 인터셉터 - 모든 요청에 토큰 추가
+api.interceptors.request.use(
+  (config) => {
+    // localStorage에서 토큰 가져오기
+    const token = localStorage.getItem('access-token')
+
+    if (token) {
+      // Authorization 헤더에 Bearer 토큰 추가
+      config.headers.Authorization = `Bearer ${token}`
+    }
+
+    return config
+  },
+  (error) => {
+    return Promise.reject(error)
+  },
+)
+
+// 응답 인터셉터 - 에러 처리
+api.interceptors.response.use(
+  (response) => {
+    return response
+  },
+  (error) => {
+    // 401 Unauthorized 에러 처리
+    if (error.response && error.response.status === 401) {
+      console.error('인증 에러: 토큰이 만료되었거나 유효하지 않습니다.')
+      // 필요시 로그인 페이지로 리다이렉트
+      // router.push('/login');
+    }
+
+    return Promise.reject(error)
+  },
+)
+
+export default api

--- a/src/api/fraud.js
+++ b/src/api/fraud.js
@@ -1,0 +1,99 @@
+import api from './axiosConfig'
+
+// 사기 위험도 API
+export const fraudApi = {
+  // 위험도 체크 목록 조회
+  getRiskCheckList: async (page = 1, size = 10) => {
+    try {
+      const response = await api.get('/api/fraud-risk', {
+        params: { page, size },
+      })
+      return response.data
+    } catch (error) {
+      console.error('위험도 체크 목록 조회 실패:', error)
+      throw error
+    }
+  },
+
+  // PDF 문서 분석 (OCR)
+  analyzeDocuments: async (registryFile, buildingFile, homeId) => {
+    try {
+      const formData = new FormData()
+      formData.append('registryFile', registryFile)
+      formData.append('buildingFile', buildingFile)
+      formData.append('homeId', homeId)
+
+      const response = await api.post('/api/fraud-risk/documents', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+        timeout: 30000, // 30초 타임아웃 (OCR 처리 시간 고려)
+      })
+      return response.data
+    } catch (error) {
+      console.error('문서 분석 실패:', error)
+      throw error
+    }
+  },
+
+  // 위험도 분석
+  analyzeRisk: async (analysisData) => {
+    try {
+      const response = await api.post('/api/fraud-risk/analyze', analysisData, {
+        timeout: 30000, // 30초 타임아웃 (AI 분석 시간 고려)
+      })
+      return response.data
+    } catch (error) {
+      console.error('위험도 분석 실패:', error)
+      throw error
+    }
+  },
+
+  // 위험도 체크 상세 조회
+  getRiskCheckDetail: async (riskCheckId) => {
+    try {
+      const response = await api.get(`/api/fraud-risk/${riskCheckId}`)
+      return response.data
+    } catch (error) {
+      console.error('위험도 체크 상세 조회 실패:', error)
+      throw error
+    }
+  },
+
+  // 위험도 체크 삭제
+  deleteRiskCheck: async (riskCheckId) => {
+    try {
+      const response = await api.delete(`/api/fraud-risk/${riskCheckId}`)
+      return response.data
+    } catch (error) {
+      console.error('위험도 체크 삭제 실패:', error)
+      throw error
+    }
+  },
+
+  // 찜한 매물 목록 조회
+  getLikedHomes: async () => {
+    try {
+      const response = await api.get('/api/fraud-risk/liked-homes')
+      return response.data
+    } catch (error) {
+      console.error('찜한 매물 목록 조회 실패:', error)
+      throw error
+    }
+  },
+
+  // 채팅 중인 매물 목록 조회 (구매자로서)
+  getChattingHomes: async (page = 1, size = 10) => {
+    try {
+      const response = await api.get('/api/fraud-risk/chatting-homes', {
+        params: { page, size },
+      })
+      return response.data
+    } catch (error) {
+      console.error('채팅 중인 매물 목록 조회 실패:', error)
+      throw error
+    }
+  },
+}
+
+export default fraudApi

--- a/src/components/common/PropertyImage.vue
+++ b/src/components/common/PropertyImage.vue
@@ -1,0 +1,135 @@
+<script setup>
+import { ref, computed } from 'vue'
+import PropertyImagePlaceholder from './PropertyImagePlaceholder.vue'
+
+const props = defineProps({
+  src: {
+    type: String,
+    default: ''
+  },
+  alt: {
+    type: String,
+    default: '매물 이미지'
+  },
+  propertyType: {
+    type: String,
+    default: '매물'
+  },
+  size: {
+    type: String,
+    default: 'large' // 'small', 'medium', 'large'
+  },
+  rounded: {
+    type: String,
+    default: 'xl' // 'none', 'sm', 'md', 'lg', 'xl', '2xl', 'full'
+  }
+})
+
+const imageError = ref(false)
+const imageLoading = ref(true)
+
+const handleImageError = () => {
+  imageError.value = true
+  imageLoading.value = false
+}
+
+const handleImageLoad = () => {
+  imageError.value = false
+  imageLoading.value = false
+}
+
+// 이미지가 유효하지 않은지 확인
+const isInvalidImage = computed(() => {
+  return !props.src || 
+         props.src === '/property-placeholder.jpg' || 
+         props.src.includes('example.com') ||
+         imageError.value
+})
+
+const sizeClasses = computed(() => {
+  switch (props.size) {
+    case 'small':
+      return 'w-24 h-24'
+    case 'medium':
+      return 'w-32 h-32'
+    case 'large':
+      return 'w-48 h-48'
+    default:
+      return 'w-48 h-48'
+  }
+})
+
+const roundedClasses = computed(() => {
+  switch (props.rounded) {
+    case 'none':
+      return 'rounded-none'
+    case 'sm':
+      return 'rounded-sm'
+    case 'md':
+      return 'rounded-md'
+    case 'lg':
+      return 'rounded-lg'
+    case 'xl':
+      return 'rounded-xl'
+    case '2xl':
+      return 'rounded-2xl'
+    case 'full':
+      return 'rounded-full'
+    default:
+      return 'rounded-xl'
+  }
+})
+
+const imageClasses = computed(() => {
+  return [
+    sizeClasses.value,
+    roundedClasses.value,
+    'object-cover'
+  ].join(' ')
+})
+</script>
+
+<template>
+  <div class="relative inline-block">
+    <!-- 로딩 상태 -->
+    <div 
+      v-if="imageLoading && !isInvalidImage"
+      :class="[
+        sizeClasses,
+        roundedClasses,
+        'bg-gray-200 animate-pulse flex items-center justify-center'
+      ]"
+    >
+      <svg 
+        class="w-8 h-8 text-gray-400" 
+        fill="none" 
+        stroke="currentColor" 
+        viewBox="0 0 24 24"
+      >
+        <path 
+          stroke-linecap="round" 
+          stroke-linejoin="round" 
+          stroke-width="2" 
+          d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+        />
+      </svg>
+    </div>
+
+    <!-- 실제 이미지 -->
+    <img
+      v-else-if="!isInvalidImage"
+      :src="src"
+      :alt="alt"
+      :class="imageClasses"
+      @error="handleImageError"
+      @load="handleImageLoad"
+    />
+
+    <!-- Placeholder -->
+    <PropertyImagePlaceholder
+      v-else
+      :type="propertyType"
+      :size="size"
+    />
+  </div>
+</template>

--- a/src/components/common/PropertyImagePlaceholder.vue
+++ b/src/components/common/PropertyImagePlaceholder.vue
@@ -1,0 +1,71 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  type: {
+    type: String,
+    default: '매물'
+  },
+  size: {
+    type: String,
+    default: 'large' // 'small', 'medium', 'large'
+  }
+})
+
+const sizeClasses = computed(() => {
+  switch (props.size) {
+    case 'small':
+      return 'w-24 h-24'
+    case 'medium':
+      return 'w-32 h-32'
+    case 'large':
+      return 'w-48 h-48'
+    default:
+      return 'w-48 h-48'
+  }
+})
+
+const iconSize = computed(() => {
+  switch (props.size) {
+    case 'small':
+      return 'w-8 h-8'
+    case 'medium':
+      return 'w-12 h-12'
+    case 'large':
+      return 'w-16 h-16'
+    default:
+      return 'w-16 h-16'
+  }
+})
+</script>
+
+<template>
+  <div 
+    :class="[
+      sizeClasses,
+      'bg-gradient-to-br from-blue-50 to-indigo-100 rounded-xl border-2 border-dashed border-blue-200',
+      'flex flex-col items-center justify-center text-blue-400 transition-colors hover:border-blue-300 hover:text-blue-500'
+    ]"
+  >
+    <!-- 건물 아이콘 -->
+    <svg 
+      :class="iconSize" 
+      fill="none" 
+      stroke="currentColor" 
+      viewBox="0 0 24 24" 
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path 
+        stroke-linecap="round" 
+        stroke-linejoin="round" 
+        stroke-width="1.5" 
+        d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+      />
+    </svg>
+    
+    <!-- 텍스트 -->
+    <span class="text-xs font-medium mt-2 text-center px-2 leading-tight">
+      {{ type }}<br />이미지
+    </span>
+  </div>
+</template>

--- a/src/components/risk-check/result/DetailedAnalysis.vue
+++ b/src/components/risk-check/result/DetailedAnalysis.vue
@@ -6,7 +6,11 @@ import IconWarningTriangle from '@/components/icons/IconWarningTriangle.vue'
 const props = defineProps({
   analysisData: {
     type: Object,
-    required: true,
+    required: false,
+  },
+  detailGroups: {
+    type: Array,
+    required: false,
   },
 })
 
@@ -45,7 +49,30 @@ const getIconClass = (status) => {
   <div class="bg-white rounded-2xl shadow-sm border border-gray-300 p-8">
     <h3 class="text-xl font-semibold text-gray-warm-700 mb-6">상세 분석 결과</h3>
 
-    <div class="space-y-8">
+    <!-- detailGroups 배열이 있을 때 표시 -->
+    <div v-if="detailGroups && detailGroups.length > 0" class="space-y-8">
+      <div v-for="(group, groupIndex) in detailGroups" :key="groupIndex">
+        <h4 class="text-lg font-semibold text-gray-warm-700 pb-2.5 border-b border-gray-300 mb-4">
+          {{ group.title }}
+        </h4>
+        <div class="space-y-4">
+          <div
+            v-for="(item, itemIndex) in group.items"
+            :key="itemIndex"
+            class="p-4 bg-gray-100 rounded-xl"
+          >
+            <div class="flex items-center gap-2 mb-2">
+              <IconCheckCircle class="text-yellow-primary" />
+              <span class="text-sm font-medium text-gray-warm-700">{{ item.title }}</span>
+            </div>
+            <p class="text-base text-gray-warm-500">{{ item.content }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 기존 detailedAnalysis 방식 (fallback) -->
+    <div v-else-if="analysisData" class="space-y-8">
       <div v-for="section in sections" :key="section.key">
         <h4 class="text-lg font-semibold text-gray-warm-700 pb-2.5 border-b border-gray-300 mb-4">
           {{ section.title }}

--- a/src/components/risk-check/result/PropertyInfoCard.vue
+++ b/src/components/risk-check/result/PropertyInfoCard.vue
@@ -1,4 +1,6 @@
 <script setup>
+import PropertyImage from '@/components/common/PropertyImage.vue'
+
 const props = defineProps({
   propertyInfo: {
     type: Object,
@@ -14,10 +16,13 @@ const props = defineProps({
 <template>
   <div class="bg-white rounded-2xl shadow-sm border border-gray-300 p-8">
     <div class="flex gap-6">
-      <img
+      <!-- 매물 이미지 -->
+      <PropertyImage
         :src="propertyInfo.image"
-        alt="`${propertyInfo.title} 매물 이미지`"
-        class="w-48 h-48 rounded-xl object-cover"
+        :alt="`${propertyInfo.title} 매물 이미지`"
+        :property-type="propertyInfo.type"
+        size="large"
+        rounded="xl"
       />
       <div class="flex-1">
         <h2 class="text-2xl font-bold text-gray-warm-700 mb-2">

--- a/src/stores/fraud.js
+++ b/src/stores/fraud.js
@@ -1,0 +1,52 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useFraudStore = defineStore('fraud', () => {
+  // OCR 분석 결과를 임시 저장
+  const documentAnalysisData = ref(null)
+
+  // 문서 분석 데이터 저장
+  const setDocumentAnalysisData = (data) => {
+    documentAnalysisData.value = {
+      homeId: data.homeId,
+      registryDocument: data.registryDocument,
+      buildingDocument: data.buildingDocument,
+      registryFileUrl: data.registryFileUrl,
+      buildingFileUrl: data.buildingFileUrl,
+      registryAnalysisStatus: data.registryAnalysisStatus,
+      buildingAnalysisStatus: data.buildingAnalysisStatus,
+      timestamp: Date.now() // 데이터 유효성 검증을 위한 타임스탬프
+    }
+  }
+
+  // 문서 분석 데이터 가져오기
+  const getDocumentAnalysisData = () => {
+    // 데이터가 없거나 30분 이상 지난 경우 null 반환
+    if (!documentAnalysisData.value) {
+      return null
+    }
+
+    const now = Date.now()
+    const dataAge = now - documentAnalysisData.value.timestamp
+    const thirtyMinutes = 30 * 60 * 1000
+
+    if (dataAge > thirtyMinutes) {
+      clearDocumentAnalysisData()
+      return null
+    }
+
+    return documentAnalysisData.value
+  }
+
+  // 문서 분석 데이터 삭제
+  const clearDocumentAnalysisData = () => {
+    documentAnalysisData.value = null
+  }
+
+  return {
+    documentAnalysisData,
+    setDocumentAnalysisData,
+    getDocumentAnalysisData,
+    clearDocumentAnalysisData
+  }
+})


### PR DESCRIPTION
## 🚀 관련 이슈

- close #31 

## 🔑 주요 변경사항

<!-- 내가 작업한 내용에 대해 작성해주세요! -->

- 사기위험도 분석 페이지 API 연동

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 라벨을 등록했는가?
- [x] 리뷰어를 지정했는가?

## 📢 To Reviewers

<!-- 선택 사항 -->

## 📸 스크린샷 or 실행영상
이전과 동일

## ↗️ 개선 사항

<!-- 선택 사항 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 부동산 이미지 표시 전용 컴포넌트와 플레이스홀더 컴포넌트가 추가되었습니다.
  * 부동산 위험 분석 및 문서 OCR 분석을 위한 API 연동 기능이 도입되었습니다.
  * 최근 분석 이력, 즐겨찾기, 채팅 매물 등 주요 정보가 실시간 API 데이터로 제공됩니다.
  * 분석 결과 화면이 동적 API 데이터 기반으로 개선되었습니다.
  * 위험 분석 임시 데이터 관리를 위한 스토어가 추가되었습니다.

* **버그 수정**
  * 데이터 로딩, 오류, 유효하지 않은 이미지 등에 대한 예외 처리 및 사용자 안내가 강화되었습니다.

* **리팩터**
  * 기존 목업 데이터 사용 로직이 모두 실제 API 연동 방식으로 변경되었습니다.
  * 분석 결과, 상세 분석 등 주요 컴포넌트의 데이터 구조 및 렌더링 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->