### PR TITLE
[FEAT] 메인 헤더에 알람 드롭다운 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@stomp/stompjs": "^7.1.1",
+        "@vueuse/core": "^13.6.0",
         "axios": "^1.10.0",
         "moment": "^2.30.1",
         "pinia": "^3.0.3",
@@ -1685,6 +1686,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -1936,6 +1943,44 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
       "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
       "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.6.0.tgz",
+      "integrity": "sha512-DJbD5fV86muVmBgS9QQPddVX7d9hWYswzlf4bIyUD2dj8GC46R1uNClZhVAmsdVts4xb2jwp1PbpuiA50Qee1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.6.0",
+        "@vueuse/shared": "13.6.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.6.0.tgz",
+      "integrity": "sha512-rnIH7JvU7NjrpexTsl2Iwv0V0yAx9cw7+clymjKuLSXG0QMcLD0LDgdNmXic+qL0SGvgSVPEpM9IDO/wqo1vkQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.6.0.tgz",
+      "integrity": "sha512-pDykCSoS2T3fsQrYqf9SyF0QXWHmcGPQ+qiOVjlYSzlWd9dgppB2bFSM1GgKKkt7uzn0BBMV3IbJsUfHG2+BCg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@stomp/stompjs": "^7.1.1",
+    "@vueuse/core": "^13.6.0",
     "axios": "^1.10.0",
     "moment": "^2.30.1",
     "pinia": "^3.0.3",

--- a/src/assets/icons/AlarmIcon.vue
+++ b/src/assets/icons/AlarmIcon.vue
@@ -1,0 +1,29 @@
+<template>
+  <svg
+    :width="props.width"
+    :height="props.height"
+    viewBox="0 0 40 48"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill="currentColor"
+      d="M20 36C22.21 36 24 37.79 24 40C24 42.21 22.21 44 20 44C17.79 44 16 42.21 16 40C16 37.79 17.79 36 20 36ZM32 14C32 10.8174 30.7357 7.76516 28.4853 5.51472C26.2348 3.26428 23.1826 2 20 2C16.8174 2 13.7652 3.26428 11.5147 5.51472C9.26428 7.76516 8 10.8174 8 14C8 28 2 32 2 32H38C38 32 32 28 32 14Z"
+    />
+  </svg>
+</template>
+
+<script setup>
+import { defineProps } from 'vue'
+
+const props = defineProps({
+  width: {
+    type: [String, Number],
+    default: '12',
+  },
+  height: {
+    type: [String, Number],
+    default: '12',
+  },
+})
+</script>

--- a/src/components/alarm/AlarmCard.vue
+++ b/src/components/alarm/AlarmCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="px-4 py-3 border-b border-gray-100 hover:bg-gray-50 cursor-pointer">
+    <p class="text-sm text-gray-800">{{ title }}</p>
+    <p class="text-xs text-gray-500 mt-1">{{ time }}</p>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  title: String,
+  time: String,
+})
+</script>

--- a/src/components/alarm/AlarmDropdown.vue
+++ b/src/components/alarm/AlarmDropdown.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="absolute right-0 mt-2 w-80 white-box shadow-lg" v-show="isVisible" ref="dropdownRef">
+    <div class="pb-2 border-b border-gray-200 font-semibold">알림</div>
+    <div class="min-h-24 max-h-80 overflow-y-auto flex flex-col" v-if="alarms.length">
+      <AlarmCard
+        v-for="(item, index) in alarms"
+        :key="index"
+        :title="item.title"
+        :time="item.time"
+      />
+    </div>
+    <div v-else class="min-h-24 flex items-center text-sm text-gray-400">
+      새로운 알림이 없습니다.
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onClickOutside } from '@vueuse/core'
+import { ref } from 'vue'
+import AlarmCard from './AlarmCard.vue'
+
+defineProps({
+  isVisible: Boolean,
+})
+
+const emit = defineEmits(['close'])
+const dropdownRef = ref(null)
+
+onClickOutside(dropdownRef, (event) => {
+  if (event.target.closest('.alarm-toggle-button')) return
+  emit('close')
+})
+
+const alarms = [
+  { title: '계약서 수정 요청이 도착했어요.', time: '3분 전' },
+  { title: '새 채팅 메시지가 있어요.', time: '10분 전' },
+  { title: '임차인이 계약을 수락했습니다.', time: '1시간 전' },
+  { title: '계약서 수정 요청이 도착했어요.', time: '16시간 전' },
+  { title: '새 채팅 메시지가 있어요.', time: '1일 전' },
+  { title: '임차인이 계약을 수락했습니다.', time: '3일 전' },
+]
+</script>

--- a/src/components/alarm/AlarmDropdown.vue
+++ b/src/components/alarm/AlarmDropdown.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="absolute right-0 mt-2 w-80 white-box shadow-lg" v-show="isVisible" ref="dropdownRef">
+  <div
+    class="absolute right-0 mt-2 w-80 white-box shadow-lg z-50"
+    v-show="isVisible"
+    ref="dropdownRef"
+  >
     <div class="pb-2 border-b border-gray-200 font-semibold">알림</div>
     <div class="min-h-24 max-h-80 overflow-y-auto flex flex-col" v-if="alarms.length">
       <AlarmCard

--- a/src/components/layouts/menu/AuthSection.vue
+++ b/src/components/layouts/menu/AuthSection.vue
@@ -3,12 +3,15 @@
     <!-- 로그인 했을 때-->
     <template v-if="authStore.isLoggedIn">
       <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-full bg-gray-700 flex items-center justify-center">
-          <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-            <path
-              d="M12 12c2.67 0 8 1.34 8 4v2H4v-2c0-2.66 5.33-4 8-4zm0-2a4 4 0 100-8 4 4 0 000 8z"
-            />
-          </svg>
+        <div class="relative">
+          <div
+            class="w-8 h-8 rounded-full bg-gray-warm-700 flex items-center justify-center cursor-pointer hover:bg-gray-warm-500 alarm-toggle-button"
+            @click="toggleDropdown"
+          >
+            <AlarmIcon class="w-5 h-5 text-white" />
+          </div>
+
+          <AlarmDropdown :is-visible="showDropdown" @close="showDropdown = false" />
         </div>
         <BaseButton @click="router.push('/auth/mypage')" variant="primary" class="rounded-md">
           마이페이지
@@ -29,12 +32,21 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import BaseButton from '@/components/common/BaseButton.vue'
 import config from '@/config'
+import AlarmIcon from '@/assets/icons/AlarmIcon.vue'
+import AlarmDropdown from '@/components/alarm/AlarmDropdown.vue'
 
 const router = useRouter()
 const accountMenus = config.accountMenus
 const authStore = useAuthStore()
+
+const showDropdown = ref(false)
+
+const toggleDropdown = () => {
+  showDropdown.value = !showDropdown.value
+}
 </script>


### PR DESCRIPTION
## 🚀 관련 이슈

- close #56

## 🔑 주요 변경사항

- 알람 아이콘 추가
- 메인 헤더에 알람 드롭다운 추가
- vueuse/core 설치

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 라벨을 등록했는가?
- [x] 리뷰어를 지정했는가?

## 📢 To Reviewers

실행 시 npm i 한 번씩 해주세요!

## 📸 스크린샷 or 실행영상
<img width="477" height="470" alt="image" src="https://github.com/user-attachments/assets/485656d9-7c4d-4214-88e6-099df4609e21" />

## ↗️ 개선 사항
추후 AlarmCard에 필요한 요소로 변경해야 합니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 알림 아이콘 및 알림 드롭다운 컴포넌트가 추가되어, 클릭 시 최근 알림 목록을 확인할 수 있습니다.
  * 알림 카드 컴포넌트가 도입되어 각 알림의 제목과 시간을 표시합니다.

* **기타**
  * 새로운 외부 라이브러리 `@vueuse/core`가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->