### PR TITLE
[Refacor] 매물 페이지 연동

### DIFF
--- a/src/components/homes/homecreate/Step2PriceInfo.vue
+++ b/src/components/homes/homecreate/Step2PriceInfo.vue
@@ -39,8 +39,7 @@ const utilityItems = {
   gas: '가스료',
   water: '수도료',
   internet: '인터넷',
-  cableTV: '케이블TV',
-  heating: '난방비',
+  cleaning: '청소비',
 }
 
 // 관리비 항목 토글
@@ -98,7 +97,9 @@ function isChecked(label) {
       </div>
 
       <div>
-        <label class="block mb-1 text-sm font-medium">관리비</label>
+        <label class="block mb-1 text-sm font-medium"
+          >관리비<span class="text-red-500">*</span></label
+        >
         <div class="relative w-full">
           <input
             type="text"
@@ -168,7 +169,9 @@ function isChecked(label) {
       </div>
 
       <div>
-        <label class="block mb-1 text-sm font-medium">관리비 </label>
+        <label class="block mb-1 text-sm font-medium"
+          >관리비 <span class="text-red-500">*</span></label
+        >
         <div class="relative w-full">
           <input
             type="text"

--- a/src/components/homes/homecreate/Step3DetailInfo.vue
+++ b/src/components/homes/homecreate/Step3DetailInfo.vue
@@ -39,7 +39,9 @@ const homeDirectionOptions = [
     <!-- 전용면적 & 공급면적 -->
     <div class="grid grid-cols-2 gap-6">
       <div>
-        <label class="block mb-1 text-sm font-medium">전용면적 *</label>
+        <label class="block mb-1 text-sm font-medium"
+          >전용면적 <span class="text-red-500">*</span></label
+        >
         <div class="relative">
           <input
             type="number"
@@ -73,7 +75,9 @@ const homeDirectionOptions = [
     <!-- 방/욕실 -->
     <div class="grid grid-cols-2 gap-6">
       <div>
-        <label class="block mb-1 text-sm font-medium">방 개수 *</label>
+        <label class="block mb-1 text-sm font-medium"
+          >방 개수 <span class="text-red-500">*</span></label
+        >
         <div class="relative">
           <input
             type="number"
@@ -88,7 +92,9 @@ const homeDirectionOptions = [
         </div>
       </div>
       <div>
-        <label class="block mb-1 text-sm font-medium">욕실 개수 *</label>
+        <label class="block mb-1 text-sm font-medium"
+          >욕실 개수 <span class="text-red-500">*</span></label
+        >
         <div class="relative">
           <input
             type="number"
@@ -107,7 +113,9 @@ const homeDirectionOptions = [
     <!-- 층 정보 -->
     <div class="grid grid-cols-2 gap-6">
       <div>
-        <label class="block mb-1 text-sm font-medium">현재 층 *</label>
+        <label class="block mb-1 text-sm font-medium"
+          >현재 층 <span class="text-red-500">*</span></label
+        >
         <input
           type="number"
           min="0"
@@ -119,7 +127,9 @@ const homeDirectionOptions = [
         />
       </div>
       <div>
-        <label class="block mb-1 text-sm font-medium">총 층수 *</label>
+        <label class="block mb-1 text-sm font-medium"
+          >총 층수 <span class="text-red-500">*</span></label
+        >
         <input
           type="number"
           min="0"
@@ -134,7 +144,9 @@ const homeDirectionOptions = [
 
     <!-- 사용 승인일 -->
     <div>
-      <label class="block mb-1 text-sm font-medium">사용 승인일</label>
+      <label class="block mb-1 text-sm font-medium"
+        >사용 승인일<span class="text-red-500">*</span></label
+      >
       <input
         type="date"
         class="border rounded p-2 w-full max-w-xs"

--- a/src/components/homes/homecreate/Step4ImageUpload.vue
+++ b/src/components/homes/homecreate/Step4ImageUpload.vue
@@ -67,9 +67,7 @@
 
     <!-- 상세 설명 -->
     <div>
-      <label for="description" class="block font-semibold mb-1">
-        상세 설명 <span class="text-red-600">*</span>
-      </label>
+      <label for="description" class="block font-semibold mb-1"> 상세 설명 </label>
       <textarea
         id="description"
         v-model="description"

--- a/src/components/homes/homedetails/ImageGallery.vue
+++ b/src/components/homes/homedetails/ImageGallery.vue
@@ -2,14 +2,20 @@
   <div class="w-full">
     <div class="relative w-full">
       <img
+        v-if="images.length > 0"
         :src="images[currentIndex]"
         alt="매물 이미지"
         class="w-full h-80 object-cover rounded-md"
         @error="handleImageError"
         loading="lazy"
       />
+      <div
+        v-else
+        class="w-full h-80 bg-gray-200 flex items-center justify-center text-gray-500 rounded-md"
+      >
+        이미지 없음
+      </div>
 
-      <!-- 이전 버튼 -->
       <button
         @click="prevImage"
         @keydown.left.prevent="prevImage"
@@ -19,7 +25,6 @@
         ◀
       </button>
 
-      <!-- 다음 버튼 -->
       <button
         @click="nextImage"
         @keydown.right.prevent="nextImage"
@@ -30,7 +35,6 @@
       </button>
     </div>
 
-    <!-- 신고/찜하기 버튼 -->
     <div class="flex justify-end gap-2 mt-2">
       <button
         @click="openReportModal"
@@ -51,7 +55,6 @@
       </button>
     </div>
 
-    <!-- 신고 사유 선택 모달 -->
     <div
       v-if="showReportModal"
       class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
@@ -93,7 +96,6 @@
       </div>
     </div>
 
-    <!-- 신고 완료 알림 모달 -->
     <div
       v-if="showReportCompleteModal"
       class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"

--- a/src/components/homes/homedetails/RoomDetails.vue
+++ b/src/components/homes/homedetails/RoomDetails.vue
@@ -70,11 +70,13 @@
         <div>
           <div class="text-gray-600 mb-2">관리비 포함 항목</div>
           <div class="flex flex-wrap gap-2">
-            <span class="bg-gray-100 text-xs px-3 py-1 rounded-full">전기료</span>
-            <span class="bg-gray-100 text-xs px-3 py-1 rounded-full">수도료</span>
-            <span class="bg-gray-100 text-xs px-3 py-1 rounded-full">가스료</span>
-            <span class="bg-gray-100 text-xs px-3 py-1 rounded-full">인터넷</span>
-            <span class="bg-gray-100 text-xs px-3 py-1 rounded-full">청소비</span>
+            <span
+              v-for="item in listing.maintenanceFeeItems"
+              :key="item.itemName"
+              class="bg-gray-100 text-xs px-3 py-1 rounded-full"
+            >
+              {{ item.itemName }}
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/homes/homedetails/RoomDetails.vue
+++ b/src/components/homes/homedetails/RoomDetails.vue
@@ -42,7 +42,7 @@
             <DirectionIcon class="text-yellow-primary" />
             방향
           </div>
-          <div class="text-black font-medium">{{ listing.homeDirection }}</div>
+          <div class="text-black font-medium">{{ displayedHomeDirection }}</div>
         </div>
 
         <div>
@@ -94,12 +94,12 @@
             <ElevatorIcon class="text-yellow-primary w-4 h-4 mb-1" />
             <span class="text-xs font-medium">엘리베이터</span>
           </div>
-          <!--          <div-->
-          <!--            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"-->
-          <!--          >-->
-          <!--            <IndividualHeatingIcon class="text-yellow-primary w-4 h-4 mb-1" />-->
-          <!--            <span class="text-xs font-medium">개별난방</span>-->
-          <!--          </div>-->
+          <div
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <IndividualHeatingIcon class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">개별난방</span>
+          </div>
           <div
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
@@ -117,7 +117,6 @@
             v-if="listing.isPet"
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
-            <!--            <DogIcon class="text-yellow-primary w-4 h-4 mb-1" />-->
             <span class="text-xs font-medium">반려동물</span>
           </div>
         </div>
@@ -245,6 +244,27 @@ const { listing } = defineProps({
     type: Object,
     required: true,
   },
+})
+
+// `homeDirection` 영문 값을 한글로 매핑하는 객체
+const homeDirectionMap = {
+  E: '동향',
+  W: '서향',
+  S: '남향',
+  N: '북향',
+  SE: '남동향',
+  SW: '남서향',
+  NE: '북동향',
+  NW: '북서향',
+}
+
+const displayedHomeDirection = computed(() => {
+  const direction = listing.homeDirection
+  if (!direction) {
+    return ''
+  }
+  const upperCaseDirection = direction.toUpperCase()
+  return homeDirectionMap[upperCaseDirection] || upperCaseDirection
 })
 
 // `itemName`과 아이콘 컴포넌트를 매핑하는 객체

--- a/src/components/homes/homedetails/RoomDetails.vue
+++ b/src/components/homes/homedetails/RoomDetails.vue
@@ -94,12 +94,12 @@
             <ElevatorIcon class="text-yellow-primary w-4 h-4 mb-1" />
             <span class="text-xs font-medium">엘리베이터</span>
           </div>
-          <div
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <IndividualHeatingIcon class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">개별난방</span>
-          </div>
+          <!--          <div-->
+          <!--            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"-->
+          <!--          >-->
+          <!--            <IndividualHeatingIcon class="text-yellow-primary w-4 h-4 mb-1" />-->
+          <!--            <span class="text-xs font-medium">개별난방</span>-->
+          <!--          </div>-->
           <div
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
@@ -107,46 +107,86 @@
             <span class="text-xs font-medium">전체난방</span>
           </div>
           <div
-            v-if="listing.is_parking_available"
+            v-if="listing.isParkingAvailable"
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
             <ParkingIcon class="text-yellow-primary w-4 h-4 mb-1" />
             <span class="text-xs font-medium">주차가능</span>
           </div>
           <div
-            v-if="listing.is_pet"
+            v-if="listing.isPet"
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
-            <ParkingIcon class="text-yellow-primary w-4 h-4 mb-1" />
+            <DogIcon class="text-yellow-primary w-4 h-4 mb-1" />
             <span class="text-xs font-medium">반려동물</span>
           </div>
         </div>
       </div>
 
-      <div class="mb-6">
-        <h3 class="font-semibold mb-3 text-sm text-gray-600">내부 시설</h3>
-        <div class="grid grid-cols-6 gap-4 text-center text-xs">
+      <div
+        v-if="categorizedFacilities['가구'] && categorizedFacilities['가구'].length > 0"
+        class="mb-6"
+      >
+        <h3 class="font-semibold mb-3 text-sm text-gray-600">가구</h3>
+        <div class="grid grid-cols-5 gap-5 text-center text-xs">
           <div
-            v-for="(item, index) in internalFacilities"
-            :key="index"
+            v-for="item in categorizedFacilities['가구']"
+            :key="item.itemId"
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
-            <component :is="item.icon" class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">{{ item.label }}</span>
+            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">{{ item.itemName }}</span>
           </div>
         </div>
       </div>
 
-      <div>
+      <div
+        v-if="categorizedFacilities['가전제품'] && categorizedFacilities['가전제품'].length > 0"
+        class="mb-6"
+      >
+        <h3 class="font-semibold mb-3 text-sm text-gray-600">가전제품</h3>
+        <div class="grid grid-cols-6 gap-4 text-center text-xs">
+          <div
+            v-for="item in categorizedFacilities['가전제품']"
+            :key="item.itemId"
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">{{ item.itemName }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="categorizedFacilities['편의시설'] && categorizedFacilities['편의시설'].length > 0"
+        class="mb-6"
+      >
+        <h3 class="font-semibold mb-3 text-sm text-gray-600">편의시설</h3>
+        <div class="grid grid-cols-6 gap-4 text-center text-xs">
+          <div
+            v-for="item in categorizedFacilities['편의시설']"
+            :key="item.itemId"
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">{{ item.itemName }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="categorizedFacilities['보안시설'] && categorizedFacilities['보안시설'].length > 0"
+        class="mb-6"
+      >
         <h3 class="font-semibold mb-3 text-sm text-gray-600">보안 시설</h3>
         <div class="grid grid-cols-6 gap-4 text-center text-xs">
           <div
-            v-for="(item, index) in securityFacilities"
-            :key="index"
+            v-for="item in categorizedFacilities['보안시설']"
+            :key="item.itemId"
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
-            <component :is="item.icon" class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">{{ item.label }}</span>
+            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">{{ item.itemName }}</span>
           </div>
         </div>
       </div>
@@ -155,7 +195,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { computed } from 'vue'
 
 import NetAreaIcon from '@/assets/icons/NetAreaIcon.vue'
 import GrossAreaIcon from '@/assets/icons/GrossAreaIcon.vue'
@@ -164,11 +204,13 @@ import CalendarIcon from '@/assets/icons/CalendarIcon.vue'
 import DirectionIcon from '@/assets/icons/DirectionIcon.vue'
 import RoomIcon from '@/assets/icons/RoomIcon.vue'
 
+// 건물 시설
 import ElevatorIcon from '@/assets/icons/ElevatorIcon.vue'
 import IndividualHeatingIcon from '@/assets/icons/IndividualHeatingIcon.vue'
 import CenterHeatingIcon from '@/assets/icons/CenterHeatingIcon.vue'
 import ParkingIcon from '@/assets/icons/ParkingIcon.vue'
-
+// import DogIcon from '@/assets/icons/DogIcon.vue' // 반려동물 아이콘
+// 가전제품
 import AirconIcon from '@/assets/icons/AirconIcon.vue'
 import TvIcon from '@/assets/icons/TvIcon.vue'
 import LaunIcon from '@/assets/icons/launIcon.vue'
@@ -176,15 +218,18 @@ import RefrigIcon from '@/assets/icons/RefrigIcon.vue'
 import InductIcon from '@/assets/icons/InductIcon.vue'
 import GasrangeIcon from '@/assets/icons/GasrangeIcon.vue'
 import ElectronicrangeIcon from '@/assets/icons/ElectronicrangeIcon.vue'
+import WallairconIcon from '@/assets/icons/WallairconIcon.vue'
+import Builtinaorcon from '@/assets/icons/builtinaorcon.vue'
+
+// 가구
 import BathIcon from '@/assets/icons/BathIcon.vue'
 import SinkIcon from '@/assets/icons/SinkIcon.vue'
 import DeskIcon from '@/assets/icons/DeskIcon.vue'
 import ClosetIcon from '@/assets/icons/ClosetIcon.vue'
 import BootbacIcon from '@/assets/icons/BootbacIcon.vue'
 import ShoeseIcon from '@/assets/icons/ShoeseIcon.vue'
-import WallairconIcon from '@/assets/icons/WallairconIcon.vue'
-import Builtinaorcon from '@/assets/icons/builtinaorcon.vue'
-
+import SofaIcon from '@/assets/icons/SofaIcon.vue' // 소파 아이콘
+// 보안 시설
 import CctvIcon from '@/assets/icons/CctvIcon.vue'
 import InterphoneIcon from '@/assets/icons/InterphoneIcon.vue'
 import DoorlockIcon from '@/assets/icons/DoorlockIcon.vue'
@@ -202,33 +247,60 @@ const { listing } = defineProps({
   },
 })
 
-const internalFacilities = ref([
-  { icon: AirconIcon, label: '에어컨' },
-  { icon: TvIcon, label: 'TV' },
-  { icon: LaunIcon, label: '세탁기' },
-  { icon: RefrigIcon, label: '냉장고' },
-  { icon: InductIcon, label: '인덕션' },
-  { icon: GasrangeIcon, label: '가스렌지' },
-  { icon: ElectronicrangeIcon, label: '전자레인지' },
-  { icon: BathIcon, label: '욕조' },
-  { icon: SinkIcon, label: '싱크대' },
-  { icon: DeskIcon, label: '책상' },
-  { icon: ClosetIcon, label: '옷장' },
-  { icon: BootbacIcon, label: '붙박이장' },
-  { icon: ShoeseIcon, label: '신발장' },
-  { icon: WallairconIcon, label: '벽걸이 에어컨' },
-  { icon: Builtinaorcon, label: '빌트인 에어컨' },
-])
+// `itemName`과 아이콘 컴포넌트를 매핑하는 객체
+const iconMap = {
+  // 가전제품
+  에어컨: AirconIcon,
+  세탁기: LaunIcon,
+  냉장고: RefrigIcon,
+  인덕션: InductIcon,
+  가스렌지: GasrangeIcon,
+  전자레인지: ElectronicrangeIcon,
+  '벽걸이 에어컨': WallairconIcon,
+  '빌트인 에어컨': Builtinaorcon,
+  TV: TvIcon,
 
-const securityFacilities = ref([
-  { icon: CctvIcon, label: 'CCTV' },
-  { icon: InterphoneIcon, label: '인터폰' },
-  { icon: DoorlockIcon, label: '도어락' },
-  { icon: CardKeyIcon, label: '카드키' },
-  { icon: BangbumIcon, label: '방범창' },
-  { icon: SecurityIcon, label: '경비' },
-  { icon: FirewarningIcon, label: '화재경보기' },
-  { icon: SohwagiIcon, label: '소화기' },
-  { icon: HyungwansecuIcon, label: '현관보안' },
-])
+  // 가구
+  욕조: BathIcon,
+  싱크대: SinkIcon,
+  책상: DeskIcon,
+  옷장: ClosetIcon,
+  붙박이장: BootbacIcon,
+  신발장: ShoeseIcon,
+  소파: SofaIcon,
+
+  // 보안 시설
+  CCTV: CctvIcon,
+  인터폰: InterphoneIcon,
+  도어락: DoorlockIcon,
+  카드키: CardKeyIcon,
+  방범창: BangbumIcon,
+  경비: SecurityIcon,
+  화재경보기: FirewarningIcon,
+  소화기: SohwagiIcon,
+  현관보안: HyungwansecuIcon,
+
+  // 편의시설 (API 응답에 따라 추가)
+  엘리베이터: ElevatorIcon,
+  주차장: ParkingIcon,
+  개별난방: IndividualHeatingIcon,
+  전체난방: CenterHeatingIcon,
+}
+
+const getIcon = (itemName) => {
+  return iconMap[itemName] || null // 매핑되지 않은 경우 null 반환
+}
+
+const categorizedFacilities = computed(() => {
+  if (!listing.facilities || !Array.isArray(listing.facilities)) {
+    return {}
+  }
+  return listing.facilities.reduce((acc, item) => {
+    if (!acc[item.categoryType]) {
+      acc[item.categoryType] = []
+    }
+    acc[item.categoryType].push(item)
+    return acc
+  }, {})
+})
 </script>

--- a/src/components/homes/homedetails/RoomDetails.vue
+++ b/src/components/homes/homedetails/RoomDetails.vue
@@ -117,7 +117,7 @@
             v-if="listing.isPet"
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
-            <DogIcon class="text-yellow-primary w-4 h-4 mb-1" />
+            <!--            <DogIcon class="text-yellow-primary w-4 h-4 mb-1" />-->
             <span class="text-xs font-medium">반려동물</span>
           </div>
         </div>

--- a/src/components/homes/homelist/FilterSidebar.vue
+++ b/src/components/homes/homelist/FilterSidebar.vue
@@ -1,6 +1,5 @@
 <template>
   <aside class="w-full md:w-64 bg-white px-4 py-6 border-r border-gray-200 space-y-6">
-    <!-- 지역 선택 -->
     <div>
       <h3 class="font-bold text-gray-800 mb-2">지역선택</h3>
       <select
@@ -22,7 +21,6 @@
       </select>
     </div>
 
-    <!-- 매물종류 -->
     <div>
       <h3 class="font-bold text-gray-800 mb-2">매물종류</h3>
       <div class="flex flex-wrap gap-2">
@@ -41,7 +39,6 @@
       </div>
     </div>
 
-    <!-- 거래유형 -->
     <div>
       <h3 class="font-bold text-gray-800 mb-2">거래유형</h3>
       <div class="flex flex-wrap gap-2 mb-4">
@@ -59,7 +56,6 @@
         </button>
       </div>
 
-      <!-- 월세 -->
       <div v-if="filters.dealType === '월세'">
         <label class="text-sm font-semibold">보증금</label>
         <input
@@ -84,7 +80,6 @@
         <div class="text-xs text-gray-500">최대: {{ filters.monthlyRange }}만원</div>
       </div>
 
-      <!-- 전세 -->
       <div v-else-if="filters.dealType === '전세'">
         <label class="text-sm font-semibold">전세가</label>
         <input
@@ -99,7 +94,6 @@
       </div>
     </div>
 
-    <!-- 평수 -->
     <div>
       <h3 class="font-bold text-gray-800 mb-2">평수</h3>
       <input
@@ -113,7 +107,6 @@
       <div class="text-xs text-gray-500">최대: {{ filters.area }}평</div>
     </div>
 
-    <!-- 방향 -->
     <div>
       <h3 class="font-bold text-gray-800 mb-2">방향</h3>
       <div class="flex flex-wrap gap-2">
@@ -132,7 +125,6 @@
       </div>
     </div>
 
-    <!-- 층수 -->
     <div>
       <h3 class="font-bold text-gray-800 mb-2">층수</h3>
       <div class="flex flex-wrap gap-2">
@@ -151,7 +143,6 @@
       </div>
     </div>
 
-    <!-- 매물조건 -->
     <div>
       <h3 class="font-bold text-gray-800 mb-2">매물조건</h3>
       <div class="flex flex-col gap-1">
@@ -162,7 +153,6 @@
       </div>
     </div>
 
-    <!-- 버튼 -->
     <div class="pt-4 space-y-2">
       <button
         class="w-full bg-yellow-primary hover:bg-yellow-500 text-white py-2 rounded font-bold"
@@ -246,45 +236,11 @@ function resetFilters() {
     conditions: [],
   }
   districtList.value = []
-  emit('filter-change', convertFiltersToDto(filters.value)) // 변환된 값 emit
+  emit('filter-change', filters.value)
 }
 
 function emitFilterChange() {
-  emit('filter-change', convertFiltersToDto(filters.value))
-}
-
-// 평 → ㎡ 단위 변환 및 DTO 필드 매핑
-function convertFiltersToDto(f) {
-  return {
-    city: f.city,
-    district: f.district,
-    houseType: f.houseType,
-    dealType: f.dealType,
-    deposit: f.depositRange,
-    monthlyRent: f.monthlyRange,
-    lease: f.leaseRange,
-    area: Math.round(f.area * 3.3058), // 평 → ㎡
-    direction: f.direction,
-    floor: convertFloor(f.floor),
-    options: f.conditions,
-  }
-}
-
-function convertFloor(label) {
-  switch (label) {
-    case '반지하':
-      return -1
-    case '1층':
-      return 1
-    case '2~5층':
-      return 3
-    case '6~9층':
-      return 7
-    case '10층 이상':
-      return 10
-    default:
-      return null
-  }
+  emit('filter-change', filters.value)
 }
 
 const directions = ['남향', '동향', '서향', '북향', '남동향', '남서향', '북동향', '북서향']

--- a/src/components/homes/homelist/ListingCard.vue
+++ b/src/components/homes/homelist/ListingCard.vue
@@ -1,30 +1,33 @@
 <template>
-  <router-link :to="`/homes/${listing.id}`" class="block">
+  <router-link :to="`/homes/${listing.homeId}`" class="block">
     <div
       class="border rounded-lg shadow-md overflow-hidden hover:shadow-lg transition duration-200"
       role="article"
       aria-label="매물 카드"
     >
-      <!-- 매물 이미지 -->
-      <img :src="listing.imageUrls?.[0]" alt="매물 사진" class="w-full h-48 object-cover" />
+      <img
+        v-if="listing.imageUrl"
+        :src="listing.imageUrl"
+        alt="매물 사진"
+        class="w-full h-48 object-cover"
+      />
+      <div v-else class="w-full h-48 bg-gray-200 flex items-center justify-center text-gray-500">
+        이미지 없음
+      </div>
 
       <div class="p-4 space-y-2">
-        <!-- 거래 유형 + 가격 -->
         <div class="flex items-center gap-2">
           <div class="text-yellow-500 font-semibold">
             {{ listing.leaseType }}
           </div>
           <div class="text-lg font-bold">
-            <!-- JEONSE → 보증금만 표시 -->
             <template v-if="listing.leaseType === '전세'">
               {{ formatNumber(listing.depositPrice) }}
             </template>
-            <!-- WOLSE → 보증금 / 월세 표시 -->
             <template v-else-if="listing.leaseType === '월세'">
               {{ formatNumber(listing.depositPrice) }} /
               {{ formatNumber(listing.monthlyRent) }}
             </template>
-            <!-- 그 외 → 둘 다 표시 -->
             <template v-else>
               {{ formatNumber(listing.depositPrice) }} /
               {{ formatNumber(listing.monthlyRent) }}
@@ -32,7 +35,6 @@
           </div>
         </div>
 
-        <!-- 주소 + 아이콘 -->
         <div class="flex items-center text-sm text-gray-600">
           <svg
             class="w-4 h-4 mr-1 text-gray-400"
@@ -56,12 +58,10 @@
           <span>{{ listing.addr1 }}</span>
         </div>
 
-        <!-- 평수, 층 -->
         <div class="text-sm text-gray-600">
           {{ convertToPyeong(listing.exclusiveArea) }}평 · {{ listing.homeFloor }}층
         </div>
 
-        <!-- 하단 정보 -->
         <div class="flex gap-2 text-xs mt-2 text-gray-500 select-none">
           <div>❤️ {{ listing.likeCnt ?? 0 }}</div>
           <div>👁️ {{ listing.viewCnt ?? 0 }}</div>

--- a/src/pages/homes/HomeCreatePage.vue
+++ b/src/pages/homes/HomeCreatePage.vue
@@ -1,325 +1,136 @@
+<script setup>
+import { computed, reactive, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import StepProgressIndicator from '@/components/homes/homecreate/StepProgressIndicator.vue'
+import Step1BasicInfo from '@/components/homes/homecreate/Step1BasicInfo.vue'
+import Step2PriceInfo from '@/components/homes/homecreate/Step2PriceInfo.vue'
+import Step3DetailInfo from '@/components/homes/homecreate/Step3DetailInfo.vue'
+import Step4ImageUpload from '@/components/homes/homecreate/Step4ImageUpload.vue'
+import BaseButton from '@/components/common/BaseButton.vue'
+
+import { createListing } from '@/apis/listing.js'
+
+const stepComponents = [Step1BasicInfo, Step2PriceInfo, Step3DetailInfo, Step4ImageUpload]
+
+const route = useRoute()
+const router = useRouter()
+const currentStep = ref(1)
+
+watch(
+  () => route.query.step,
+  (newStep) => {
+    const stepNum = parseInt(newStep)
+    if (!stepNum || stepNum < 1) currentStep.value = 1
+    else if (stepNum > stepComponents.length) currentStep.value = stepComponents.length
+    else currentStep.value = stepNum
+  },
+  { immediate: true },
+)
+
+const form = reactive({
+  residenceType: '',
+  leaseType: '',
+  addr1: '',
+  addr2: '',
+  depositPrice: '',
+  monthlyRent: '',
+  maintenanceFee: '',
+  supplyArea: 0,
+  exclusiveArea: 0,
+  roomCnt: 0,
+  bathroomCount: 0,
+  homeFloor: 0,
+  buildingTotalFloors: 0,
+  buildDate: '', // string "yyyy-MM-dd"
+  homeDirection: '',
+  options: [],
+  utilities: {
+    electricity: false,
+    gas: false,
+    water: false,
+    internet: false,
+    cableTV: false,
+    heating: false,
+  },
+  description: '',
+  images: [],
+})
+
+const stepComponent = computed(() => stepComponents[currentStep.value - 1])
+
+const updateForm = (updatedFields) => {
+  Object.assign(form, updatedFields)
+}
+
+const goToStep = (step) => {
+  router.push({ query: { step: step.toString() } })
+}
+
+const utilityIdMap = {
+  electricity: 1,
+  gas: 2,
+  water: 3,
+  internet: 4,
+  cableTV: 5,
+  heating: 6,
+}
+
+const handleSubmit = async () => {
+  try {
+    const maintenanceFees = Object.keys(form.utilities)
+      .filter((key) => form.utilities[key])
+      .map((key) => ({
+        maintenanceId: utilityIdMap[key],
+        fee: 0,
+      }))
+
+    // NaN 방지용 숫자 변환 함수
+    const safeNumber = (val) => {
+      const num = Number(val)
+      return isNaN(num) ? 0 : num
+    }
+
+    const payload = {
+      ...form,
+      depositPrice: safeNumber(form.depositPrice),
+      monthlyRent: safeNumber(form.monthlyRent),
+      maintenanceFee: safeNumber(form.maintenanceFee),
+      supplyArea: safeNumber(form.supplyArea),
+      exclusiveArea: safeNumber(form.exclusiveArea),
+      roomCnt: safeNumber(form.roomCnt),
+      bathroomCount: safeNumber(form.bathroomCount),
+      homeFloor: safeNumber(form.homeFloor),
+      buildingTotalFloors: safeNumber(form.buildingTotalFloors),
+
+      options: Array.isArray(form.options) ? form.options.join(',') : '',
+      images: form.images.map((img) => img.url),
+      maintenanceFees: maintenanceFees,
+    }
+
+    console.log('최종 제출 데이터:', payload)
+    await createListing(payload)
+    alert('매물 등록 완료')
+    router.push('/')
+  } catch (e) {
+    console.error('등록 실패', e)
+    alert('매물 등록 실패')
+  }
+}
+</script>
+
 <template>
-  <div class="p-6 bg-white rounded-lg shadow-md space-y-6 text-gray-800">
-    <section>
-      <h2 class="font-bold text-lg mb-4 border-b border-gray-300 pb-2">매물 정보</h2>
-      <div class="grid grid-cols-2 md:grid-cols-3 gap-6 text-sm">
-        <div>
-          <div class="flex items-center gap-1">
-            <NetAreaIcon class="text-yellow-primary" />
-            전용면적
-          </div>
-          <div class="text-black font-medium">{{ listing?.exclusiveArea ?? 0 }}㎡</div>
-        </div>
-
-        <div>
-          <div class="flex items-center gap-1">
-            <GrossAreaIcon class="text-yellow-primary" />
-            공급면적
-          </div>
-          <div class="text-black font-medium">{{ listing?.supplyArea ?? 0 }}㎡</div>
-        </div>
-
-        <div>
-          <div class="flex items-center gap-1">
-            <FloorIcon class="text-yellow-primary" />
-            현재층 / 총층
-          </div>
-          <div class="text-black font-medium">
-            {{ listing?.homeFloor }}층 / {{ listing?.buildingTotalFloors }}층
-          </div>
-        </div>
-
-        <div>
-          <div class="flex items-center gap-1">
-            <CalendarIcon class="text-yellow-primary" />
-            사용승인일
-          </div>
-          <div class="text-black font-medium">{{ listing?.buildDate }}</div>
-        </div>
-
-        <div>
-          <div class="flex items-center gap-1">
-            <DirectionIcon class="text-yellow-primary" />
-            방향
-          </div>
-          <div class="text-black font-medium">{{ displayedHomeDirection }}</div>
-        </div>
-
-        <div>
-          <div class="flex items-center gap-1">
-            <RoomIcon class="text-yellow-primary" />
-            방 / 욕실 수
-          </div>
-          <div class="text-black font-medium">
-            {{ listing?.roomCnt }}개 / {{ listing?.bathroomCount }}개
-          </div>
-        </div>
+  <div class="max-w-4xl mx-auto p-6 space-y-6">
+    <StepProgressIndicator :currentStep="currentStep" />
+    <component :is="stepComponent" :form="form" @update:form="updateForm" />
+    <div class="flex justify-between mt-10">
+      <BaseButton v-if="currentStep > 1" @click="goToStep(currentStep - 1)">이전</BaseButton>
+      <div class="ml-auto">
+        <BaseButton v-if="currentStep < stepComponents.length" @click="goToStep(currentStep + 1)">
+          다음
+        </BaseButton>
+        <BaseButton v-else @click="handleSubmit" class="ml-2">저장</BaseButton>
       </div>
-    </section>
-
-    <section>
-      <h2 class="font-bold text-lg mb-4 border-b border-gray-300 pb-2">관리비 정보</h2>
-      <div class="space-y-3 text-sm">
-        <div class="flex justify-between items-center">
-          <div class="font-semibold">월 관리비</div>
-          <div class="text-yellow-primary font-bold text-lg">
-            {{ listing?.maintenanceFee ?? 0 }}만원
-          </div>
-        </div>
-
-        <div>
-          <div class="text-gray-600 mb-2">관리비 포함 항목</div>
-          <div class="flex flex-wrap gap-2">
-            <span
-              v-for="item in listing?.maintenanceFeeItems"
-              :key="item.itemName"
-              class="bg-gray-100 text-xs px-3 py-1 rounded-full"
-            >
-              {{ item.itemName }}
-            </span>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section>
-      <h2 class="font-bold text-lg mb-4 border-b border-gray-300 pb-2">시설 정보</h2>
-
-      <div class="mb-6">
-        <h3 class="font-semibold mb-3 text-sm text-gray-600">건물 시설</h3>
-        <div class="grid grid-cols-5 gap-5 text-center text-xs">
-          <div
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <ElevatorIcon class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">엘리베이터</span>
-          </div>
-          <div
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <IndividualHeatingIcon class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">개별난방</span>
-          </div>
-          <div
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <CenterHeatingIcon class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">전체난방</span>
-          </div>
-          <div
-            v-if="listing?.isParkingAvailable"
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <ParkingIcon class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">주차가능</span>
-          </div>
-          <div
-            v-if="listing?.isPet"
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <DogIcon class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">반려동물</span>
-          </div>
-        </div>
-      </div>
-
-      <div
-        v-if="categorizedFacilities['가구'] && categorizedFacilities['가구'].length > 0"
-        class="mb-6"
-      >
-        <h3 class="font-semibold mb-3 text-sm text-gray-600">가구</h3>
-        <div class="grid grid-cols-5 gap-5 text-center text-xs">
-          <div
-            v-for="item in categorizedFacilities['가구']"
-            :key="item.itemId"
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">{{ item.itemName }}</span>
-          </div>
-        </div>
-      </div>
-
-      <div
-        v-if="categorizedFacilities['가전제품'] && categorizedFacilities['가전제품'].length > 0"
-        class="mb-6"
-      >
-        <h3 class="font-semibold mb-3 text-sm text-gray-600">가전제품</h3>
-        <div class="grid grid-cols-6 gap-4 text-center text-xs">
-          <div
-            v-for="item in categorizedFacilities['가전제품']"
-            :key="item.itemId"
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">{{ item.itemName }}</span>
-          </div>
-        </div>
-      </div>
-
-      <div
-        v-if="categorizedFacilities['편의시설'] && categorizedFacilities['편의시설'].length > 0"
-        class="mb-6"
-      >
-        <h3 class="font-semibold mb-3 text-sm text-gray-600">편의시설</h3>
-        <div class="grid grid-cols-6 gap-4 text-center text-xs">
-          <div
-            v-for="item in categorizedFacilities['편의시설']"
-            :key="item.itemId"
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">{{ item.itemName }}</span>
-          </div>
-        </div>
-      </div>
-
-      <div
-        v-if="categorizedFacilities['보안시설'] && categorizedFacilities['보안시설'].length > 0"
-        class="mb-6"
-      >
-        <h3 class="font-semibold mb-3 text-sm text-gray-600">보안 시설</h3>
-        <div class="grid grid-cols-6 gap-4 text-center text-xs">
-          <div
-            v-for="item in categorizedFacilities['보안시설']"
-            :key="item.itemId"
-            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
-          >
-            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
-            <span class="text-xs font-medium">{{ item.itemName }}</span>
-          </div>
-        </div>
-      </div>
-    </section>
+    </div>
   </div>
 </template>
-
-<script setup>
-import { computed } from 'vue'
-
-import NetAreaIcon from '@/assets/icons/NetAreaIcon.vue'
-import GrossAreaIcon from '@/assets/icons/GrossAreaIcon.vue'
-import FloorIcon from '@/assets/icons/FloorIcon.vue'
-import CalendarIcon from '@/assets/icons/CalendarIcon.vue'
-import DirectionIcon from '@/assets/icons/DirectionIcon.vue'
-import RoomIcon from '@/assets/icons/RoomIcon.vue'
-
-// 건물 시설
-import ElevatorIcon from '@/assets/icons/ElevatorIcon.vue'
-import IndividualHeatingIcon from '@/assets/icons/IndividualHeatingIcon.vue'
-import CenterHeatingIcon from '@/assets/icons/CenterHeatingIcon.vue'
-import ParkingIcon from '@/assets/icons/ParkingIcon.vue'
-
-// 가전제품
-import AirconIcon from '@/assets/icons/AirconIcon.vue'
-import TvIcon from '@/assets/icons/TvIcon.vue'
-import LaunIcon from '@/assets/icons/launIcon.vue'
-import RefrigIcon from '@/assets/icons/RefrigIcon.vue'
-import InductIcon from '@/assets/icons/InductIcon.vue'
-import GasrangeIcon from '@/assets/icons/GasrangeIcon.vue'
-import ElectronicrangeIcon from '@/assets/icons/ElectronicrangeIcon.vue'
-import WallairconIcon from '@/assets/icons/WallairconIcon.vue'
-import Builtinaorcon from '@/assets/icons/builtinaorcon.vue'
-
-// 가구
-import BathIcon from '@/assets/icons/BathIcon.vue'
-import SinkIcon from '@/assets/icons/SinkIcon.vue'
-import DeskIcon from '@/assets/icons/DeskIcon.vue'
-import ClosetIcon from '@/assets/icons/ClosetIcon.vue'
-import BootbacIcon from '@/assets/icons/BootbacIcon.vue'
-import ShoeseIcon from '@/assets/icons/ShoeseIcon.vue'
-import SofaIcon from '@/assets/icons/SofaIcon.vue'
-
-// 보안 시설
-import CctvIcon from '@/assets/icons/CctvIcon.vue'
-import InterphoneIcon from '@/assets/icons/InterphoneIcon.vue'
-import DoorlockIcon from '@/assets/icons/DoorlockIcon.vue'
-import CardKeyIcon from '@/assets/icons/CardKeyIcon.vue'
-import BangbumIcon from '@/assets/icons/BangbumIcon.vue'
-import SecurityIcon from '@/assets/icons/SecurityIcon.vue'
-import FirewarningIcon from '@/assets/icons/FirewarningIcon.vue'
-import SohwagiIcon from '@/assets/icons/SohwagiIcon.vue'
-import HyungwansecuIcon from '@/assets/icons/HyungwansecuIcon.vue'
-
-const { listing } = defineProps({
-  listing: {
-    type: Object,
-    required: true,
-  },
-})
-
-const iconMap = {
-  에어컨: AirconIcon,
-  세탁기: LaunIcon,
-  냉장고: RefrigIcon,
-  인덕션: InductIcon,
-  가스렌지: GasrangeIcon,
-  전자레인지: ElectronicrangeIcon,
-  '벽걸이 에어컨': WallairconIcon,
-  '빌트인 에어컨': Builtinaorcon,
-  TV: TvIcon,
-
-  욕조: BathIcon,
-  싱크대: SinkIcon,
-  책상: DeskIcon,
-  옷장: ClosetIcon,
-  붙박이장: BootbacIcon,
-  신발장: ShoeseIcon,
-  소파: SofaIcon,
-
-  CCTV: CctvIcon,
-  인터폰: InterphoneIcon,
-  도어락: DoorlockIcon,
-  카드키: CardKeyIcon,
-  방범창: BangbumIcon,
-  경비: SecurityIcon,
-  화재경보기: FirewarningIcon,
-  소화기: SohwagiIcon,
-  현관보안: HyungwansecuIcon,
-
-  엘리베이터: ElevatorIcon,
-  주차장: ParkingIcon,
-  개별난방: IndividualHeatingIcon,
-  전체난방: CenterHeatingIcon,
-}
-
-const homeDirectionMap = {
-  E: '동향',
-  W: '서향',
-  S: '남향',
-  N: '북향',
-  SE: '남동향',
-  SW: '남서향',
-  NE: '북동향',
-  NW: '북서향',
-}
-
-const getIcon = (itemName) => {
-  return iconMap[itemName] || null
-}
-
-const displayedHomeDirection = computed(() => {
-  const direction = listing?.homeDirection
-  if (!direction) {
-    return ''
-  }
-  const upperCaseDirection = direction.toUpperCase()
-  console.log('백엔드에서 받은 값:', direction)
-  console.log('매핑 키로 사용될 값:', upperCaseDirection)
-  console.log('매핑 결과:', homeDirectionMap[upperCaseDirection])
-  return homeDirectionMap[upperCaseDirection] || upperCaseDirection
-})
-
-const categorizedFacilities = computed(() => {
-  if (!listing?.facilities || !Array.isArray(listing?.facilities)) {
-    return {}
-  }
-  return listing.facilities.reduce((acc, item) => {
-    if (!acc[item.categoryType]) {
-      acc[item.categoryType] = []
-    }
-    acc[item.categoryType].push(item)
-    return acc
-  }, {})
-})
-</script>

--- a/src/pages/homes/HomeCreatePage.vue
+++ b/src/pages/homes/HomeCreatePage.vue
@@ -1,136 +1,326 @@
-<script setup>
-import { computed, reactive, ref, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
-
-import StepProgressIndicator from '@/components/homes/homecreate/StepProgressIndicator.vue'
-import Step1BasicInfo from '@/components/homes/homecreate/Step1BasicInfo.vue'
-import Step2PriceInfo from '@/components/homes/homecreate/Step2PriceInfo.vue'
-import Step3DetailInfo from '@/components/homes/homecreate/Step3DetailInfo.vue'
-import Step4ImageUpload from '@/components/homes/homecreate/Step4ImageUpload.vue'
-import BaseButton from '@/components/common/BaseButton.vue'
-
-import { createListing } from '@/apis/listing.js'
-
-const stepComponents = [Step1BasicInfo, Step2PriceInfo, Step3DetailInfo, Step4ImageUpload]
-
-const route = useRoute()
-const router = useRouter()
-const currentStep = ref(1)
-
-watch(
-  () => route.query.step,
-  (newStep) => {
-    const stepNum = parseInt(newStep)
-    if (!stepNum || stepNum < 1) currentStep.value = 1
-    else if (stepNum > stepComponents.length) currentStep.value = stepComponents.length
-    else currentStep.value = stepNum
-  },
-  { immediate: true },
-)
-
-const form = reactive({
-  residenceType: '',
-  leaseType: '',
-  addr1: '',
-  addr2: '',
-  depositPrice: '',
-  monthlyRent: '',
-  maintenanceFee: '',
-  supplyArea: 0,
-  exclusiveArea: 0,
-  roomCnt: 0,
-  bathroomCount: 0,
-  homeFloor: 0,
-  buildingTotalFloors: 0,
-  buildDate: '', // string "yyyy-MM-dd"
-  homeDirection: '',
-  options: [],
-  utilities: {
-    electricity: false,
-    gas: false,
-    water: false,
-    internet: false,
-    cableTV: false,
-    heating: false,
-  },
-  description: '',
-  images: [],
-})
-
-const stepComponent = computed(() => stepComponents[currentStep.value - 1])
-
-const updateForm = (updatedFields) => {
-  Object.assign(form, updatedFields)
-}
-
-const goToStep = (step) => {
-  router.push({ query: { step: step.toString() } })
-}
-
-const utilityIdMap = {
-  electricity: 1,
-  gas: 2,
-  water: 3,
-  internet: 4,
-  cableTV: 5,
-  heating: 6,
-}
-
-const handleSubmit = async () => {
-  try {
-    const maintenanceFees = Object.keys(form.utilities)
-      .filter((key) => form.utilities[key])
-      .map((key) => ({
-        maintenanceId: utilityIdMap[key],
-        fee: 0,
-      }))
-
-    // NaN 방지용 숫자 변환 함수
-    const safeNumber = (val) => {
-      const num = Number(val)
-      return isNaN(num) ? 0 : num
-    }
-
-    const payload = {
-      ...form,
-      depositPrice: safeNumber(form.depositPrice),
-      monthlyRent: safeNumber(form.monthlyRent),
-      maintenanceFee: safeNumber(form.maintenanceFee),
-      supplyArea: safeNumber(form.supplyArea),
-      exclusiveArea: safeNumber(form.exclusiveArea),
-      roomCnt: safeNumber(form.roomCnt),
-      bathroomCount: safeNumber(form.bathroomCount),
-      homeFloor: safeNumber(form.homeFloor),
-      buildingTotalFloors: safeNumber(form.buildingTotalFloors),
-
-      options: Array.isArray(form.options) ? form.options.join(',') : '',
-      images: form.images.map((img) => img.url),
-      maintenanceFees: maintenanceFees,
-    }
-
-    console.log('최종 제출 데이터:', payload)
-    await createListing(payload)
-    alert('매물 등록 완료')
-    router.push('/')
-  } catch (e) {
-    console.error('등록 실패', e)
-    alert('매물 등록 실패')
-  }
-}
-</script>
-
 <template>
-  <div class="max-w-4xl mx-auto p-6 space-y-6">
-    <StepProgressIndicator :currentStep="currentStep" />
-    <component :is="stepComponent" :form="form" @update:form="updateForm" />
-    <div class="flex justify-between mt-10">
-      <BaseButton v-if="currentStep > 1" @click="goToStep(currentStep - 1)">이전</BaseButton>
-      <div class="ml-auto">
-        <BaseButton v-if="currentStep < stepComponents.length" @click="goToStep(currentStep + 1)">
-          다음
-        </BaseButton>
-        <BaseButton v-else @click="handleSubmit" class="ml-2">저장</BaseButton>
+  <div class="p-6 bg-white rounded-lg shadow-md space-y-6 text-gray-800">
+    <section>
+      <h2 class="font-bold text-lg mb-4 border-b border-gray-300 pb-2">매물 정보</h2>
+      <div class="grid grid-cols-2 md:grid-cols-3 gap-6 text-sm">
+        <div>
+          <div class="flex items-center gap-1">
+            <NetAreaIcon class="text-yellow-primary" />
+            전용면적
+          </div>
+          <div class="text-black font-medium">{{ listing.exclusiveArea }}㎡</div>
+        </div>
+
+        <div>
+          <div class="flex items-center gap-1">
+            <GrossAreaIcon class="text-yellow-primary" />
+            공급면적
+          </div>
+          <div class="text-black font-medium">{{ listing.supplyArea }}㎡</div>
+        </div>
+
+        <div>
+          <div class="flex items-center gap-1">
+            <FloorIcon class="text-yellow-primary" />
+            현재층 / 총층
+          </div>
+          <div class="text-black font-medium">
+            {{ listing.homeFloor }}층 / {{ listing.buildingTotalFloors }}층
+          </div>
+        </div>
+
+        <div>
+          <div class="flex items-center gap-1">
+            <CalendarIcon class="text-yellow-primary" />
+            사용승인일
+          </div>
+          <div class="text-black font-medium">{{ listing.buildDate }}</div>
+        </div>
+
+        <div>
+          <div class="flex items-center gap-1">
+            <DirectionIcon class="text-yellow-primary" />
+            방향
+          </div>
+          <div class="text-black font-medium">{{ displayedHomeDirection }}</div>
+        </div>
+
+        <div>
+          <div class="flex items-center gap-1">
+            <RoomIcon class="text-yellow-primary" />
+            방 / 욕실 수
+          </div>
+          <div class="text-black font-medium">
+            {{ listing.roomCnt }}개 / {{ listing.bathroomCount }}개
+          </div>
+        </div>
       </div>
-    </div>
+    </section>
+
+    <section>
+      <h2 class="font-bold text-lg mb-4 border-b border-gray-300 pb-2">관리비 정보</h2>
+      <div class="space-y-3 text-sm">
+        <div class="flex justify-between items-center">
+          <div class="font-semibold">월 관리비</div>
+          <div class="text-yellow-primary font-bold text-lg">
+            {{ listing.maintenanceFee ?? 0 }}만원
+          </div>
+        </div>
+
+        <div>
+          <div class="text-gray-600 mb-2">관리비 포함 항목</div>
+          <div class="flex flex-wrap gap-2">
+            <span
+              v-for="item in listing.maintenanceFeeItems"
+              :key="item.itemName"
+              class="bg-gray-100 text-xs px-3 py-1 rounded-full"
+            >
+              {{ item.itemName }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="font-bold text-lg mb-4 border-b border-gray-300 pb-2">시설 정보</h2>
+
+      <div class="mb-6">
+        <h3 class="font-semibold mb-3 text-sm text-gray-600">건물 시설</h3>
+        <div class="grid grid-cols-5 gap-5 text-center text-xs">
+          <div
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <ElevatorIcon class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">엘리베이터</span>
+          </div>
+          <div
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <IndividualHeatingIcon class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">개별난방</span>
+          </div>
+          <div
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <CenterHeatingIcon class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">전체난방</span>
+          </div>
+          <div
+            v-if="listing.isParkingAvailable"
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <ParkingIcon class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">주차가능</span>
+          </div>
+          <div
+            v-if="listing.isPet"
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <DogIcon class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">반려동물</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="categorizedFacilities['가구'] && categorizedFacilities['가구'].length > 0"
+        class="mb-6"
+      >
+        <h3 class="font-semibold mb-3 text-sm text-gray-600">가구</h3>
+        <div class="grid grid-cols-5 gap-5 text-center text-xs">
+          <div
+            v-for="item in categorizedFacilities['가구']"
+            :key="item.itemId"
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">{{ item.itemName }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="categorizedFacilities['가전제품'] && categorizedFacilities['가전제품'].length > 0"
+        class="mb-6"
+      >
+        <h3 class="font-semibold mb-3 text-sm text-gray-600">가전제품</h3>
+        <div class="grid grid-cols-6 gap-4 text-center text-xs">
+          <div
+            v-for="item in categorizedFacilities['가전제품']"
+            :key="item.itemId"
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">{{ item.itemName }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="categorizedFacilities['편의시설'] && categorizedFacilities['편의시설'].length > 0"
+        class="mb-6"
+      >
+        <h3 class="font-semibold mb-3 text-sm text-gray-600">편의시설</h3>
+        <div class="grid grid-cols-6 gap-4 text-center text-xs">
+          <div
+            v-for="item in categorizedFacilities['편의시설']"
+            :key="item.itemId"
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">{{ item.itemName }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="categorizedFacilities['보안시설'] && categorizedFacilities['보안시설'].length > 0"
+        class="mb-6"
+      >
+        <h3 class="font-semibold mb-3 text-sm text-gray-600">보안 시설</h3>
+        <div class="grid grid-cols-6 gap-4 text-center text-xs">
+          <div
+            v-for="item in categorizedFacilities['보안시설']"
+            :key="item.itemId"
+            class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
+          >
+            <component :is="getIcon(item.itemName)" class="text-yellow-primary w-4 h-4 mb-1" />
+            <span class="text-xs font-medium">{{ item.itemName }}</span>
+          </div>
+        </div>
+      </div>
+    </section>
   </div>
 </template>
+
+<script setup>
+import { computed } from 'vue'
+
+import NetAreaIcon from '@/assets/icons/NetAreaIcon.vue'
+import GrossAreaIcon from '@/assets/icons/GrossAreaIcon.vue'
+import FloorIcon from '@/assets/icons/FloorIcon.vue'
+import CalendarIcon from '@/assets/icons/CalendarIcon.vue'
+import DirectionIcon from '@/assets/icons/DirectionIcon.vue'
+import RoomIcon from '@/assets/icons/RoomIcon.vue'
+
+// 건물 시설
+import ElevatorIcon from '@/assets/icons/ElevatorIcon.vue'
+import IndividualHeatingIcon from '@/assets/icons/IndividualHeatingIcon.vue'
+import CenterHeatingIcon from '@/assets/icons/CenterHeatingIcon.vue'
+import ParkingIcon from '@/assets/icons/ParkingIcon.vue'
+import DogIcon from '@/assets/icons/DogIcon.vue'
+
+// 가전제품
+import AirconIcon from '@/assets/icons/AirconIcon.vue'
+import TvIcon from '@/assets/icons/TvIcon.vue'
+import LaunIcon from '@/assets/icons/launIcon.vue'
+import RefrigIcon from '@/assets/icons/RefrigIcon.vue'
+import InductIcon from '@/assets/icons/InductIcon.vue'
+import GasrangeIcon from '@/assets/icons/GasrangeIcon.vue'
+import ElectronicrangeIcon from '@/assets/icons/ElectronicrangeIcon.vue'
+import WallairconIcon from '@/assets/icons/WallairconIcon.vue'
+import Builtinaorcon from '@/assets/icons/builtinaorcon.vue'
+
+// 가구
+import BathIcon from '@/assets/icons/BathIcon.vue'
+import SinkIcon from '@/assets/icons/SinkIcon.vue'
+import DeskIcon from '@/assets/icons/DeskIcon.vue'
+import ClosetIcon from '@/assets/icons/ClosetIcon.vue'
+import BootbacIcon from '@/assets/icons/BootbacIcon.vue'
+import ShoeseIcon from '@/assets/icons/ShoeseIcon.vue'
+import SofaIcon from '@/assets/icons/SofaIcon.vue'
+
+// 보안 시설
+import CctvIcon from '@/assets/icons/CctvIcon.vue'
+import InterphoneIcon from '@/assets/icons/InterphoneIcon.vue'
+import DoorlockIcon from '@/assets/icons/DoorlockIcon.vue'
+import CardKeyIcon from '@/assets/icons/CardKeyIcon.vue'
+import BangbumIcon from '@/assets/icons/BangbumIcon.vue'
+import SecurityIcon from '@/assets/icons/SecurityIcon.vue'
+import FirewarningIcon from '@/assets/icons/FirewarningIcon.vue'
+import SohwagiIcon from '@/assets/icons/SohwagiIcon.vue'
+import HyungwansecuIcon from '@/assets/icons/HyungwansecuIcon.vue'
+
+const { listing } = defineProps({
+  listing: {
+    type: Object,
+    required: true,
+  },
+})
+
+const iconMap = {
+  에어컨: AirconIcon,
+  세탁기: LaunIcon,
+  냉장고: RefrigIcon,
+  인덕션: InductIcon,
+  가스렌지: GasrangeIcon,
+  전자레인지: ElectronicrangeIcon,
+  '벽걸이 에어컨': WallairconIcon,
+  '빌트인 에어컨': Builtinaorcon,
+  TV: TvIcon,
+
+  욕조: BathIcon,
+  싱크대: SinkIcon,
+  책상: DeskIcon,
+  옷장: ClosetIcon,
+  붙박이장: BootbacIcon,
+  신발장: ShoeseIcon,
+  소파: SofaIcon,
+
+  CCTV: CctvIcon,
+  인터폰: InterphoneIcon,
+  도어락: DoorlockIcon,
+  카드키: CardKeyIcon,
+  방범창: BangbumIcon,
+  경비: SecurityIcon,
+  화재경보기: FirewarningIcon,
+  소화기: SohwagiIcon,
+  현관보안: HyungwansecuIcon,
+
+  엘리베이터: ElevatorIcon,
+  주차장: ParkingIcon,
+  개별난방: IndividualHeatingIcon,
+  전체난방: CenterHeatingIcon,
+}
+
+const homeDirectionMap = {
+  E: '동향',
+  W: '서향',
+  S: '남향',
+  N: '북향',
+  SE: '남동향',
+  SW: '남서향',
+  NE: '북동향',
+  NW: '북서향',
+}
+
+const getIcon = (itemName) => {
+  return iconMap[itemName] || null
+}
+
+const displayedHomeDirection = computed(() => {
+  const direction = listing.homeDirection
+  if (!direction) {
+    return ''
+  }
+  const upperCaseDirection = direction.toUpperCase()
+  console.log('백엔드에서 받은 값:', direction)
+  console.log('매핑 키로 사용될 값:', upperCaseDirection)
+  console.log('매핑 결과:', homeDirectionMap[upperCaseDirection])
+  return homeDirectionMap[upperCaseDirection] || upperCaseDirection
+})
+
+const categorizedFacilities = computed(() => {
+  if (!listing.facilities || !Array.isArray(listing.facilities)) {
+    return {}
+  }
+  return listing.facilities.reduce((acc, item) => {
+    if (!acc[item.categoryType]) {
+      acc[item.categoryType] = []
+    }
+    acc[item.categoryType].push(item)
+    return acc
+  }, {})
+})
+</script>

--- a/src/pages/homes/HomeCreatePage.vue
+++ b/src/pages/homes/HomeCreatePage.vue
@@ -8,7 +8,7 @@
             <NetAreaIcon class="text-yellow-primary" />
             전용면적
           </div>
-          <div class="text-black font-medium">{{ listing.exclusiveArea }}㎡</div>
+          <div class="text-black font-medium">{{ listing?.exclusiveArea ?? 0 }}㎡</div>
         </div>
 
         <div>
@@ -16,7 +16,7 @@
             <GrossAreaIcon class="text-yellow-primary" />
             공급면적
           </div>
-          <div class="text-black font-medium">{{ listing.supplyArea }}㎡</div>
+          <div class="text-black font-medium">{{ listing?.supplyArea ?? 0 }}㎡</div>
         </div>
 
         <div>
@@ -25,7 +25,7 @@
             현재층 / 총층
           </div>
           <div class="text-black font-medium">
-            {{ listing.homeFloor }}층 / {{ listing.buildingTotalFloors }}층
+            {{ listing?.homeFloor }}층 / {{ listing?.buildingTotalFloors }}층
           </div>
         </div>
 
@@ -34,7 +34,7 @@
             <CalendarIcon class="text-yellow-primary" />
             사용승인일
           </div>
-          <div class="text-black font-medium">{{ listing.buildDate }}</div>
+          <div class="text-black font-medium">{{ listing?.buildDate }}</div>
         </div>
 
         <div>
@@ -51,7 +51,7 @@
             방 / 욕실 수
           </div>
           <div class="text-black font-medium">
-            {{ listing.roomCnt }}개 / {{ listing.bathroomCount }}개
+            {{ listing?.roomCnt }}개 / {{ listing?.bathroomCount }}개
           </div>
         </div>
       </div>
@@ -63,7 +63,7 @@
         <div class="flex justify-between items-center">
           <div class="font-semibold">월 관리비</div>
           <div class="text-yellow-primary font-bold text-lg">
-            {{ listing.maintenanceFee ?? 0 }}만원
+            {{ listing?.maintenanceFee ?? 0 }}만원
           </div>
         </div>
 
@@ -71,7 +71,7 @@
           <div class="text-gray-600 mb-2">관리비 포함 항목</div>
           <div class="flex flex-wrap gap-2">
             <span
-              v-for="item in listing.maintenanceFeeItems"
+              v-for="item in listing?.maintenanceFeeItems"
               :key="item.itemName"
               class="bg-gray-100 text-xs px-3 py-1 rounded-full"
             >
@@ -107,14 +107,14 @@
             <span class="text-xs font-medium">전체난방</span>
           </div>
           <div
-            v-if="listing.isParkingAvailable"
+            v-if="listing?.isParkingAvailable"
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
             <ParkingIcon class="text-yellow-primary w-4 h-4 mb-1" />
             <span class="text-xs font-medium">주차가능</span>
           </div>
           <div
-            v-if="listing.isPet"
+            v-if="listing?.isPet"
             class="flex flex-col items-center bg-gray-100 px-3 py-2 rounded-md shadow-sm text-gray-700"
           >
             <DogIcon class="text-yellow-primary w-4 h-4 mb-1" />
@@ -209,7 +209,6 @@ import ElevatorIcon from '@/assets/icons/ElevatorIcon.vue'
 import IndividualHeatingIcon from '@/assets/icons/IndividualHeatingIcon.vue'
 import CenterHeatingIcon from '@/assets/icons/CenterHeatingIcon.vue'
 import ParkingIcon from '@/assets/icons/ParkingIcon.vue'
-import DogIcon from '@/assets/icons/DogIcon.vue'
 
 // 가전제품
 import AirconIcon from '@/assets/icons/AirconIcon.vue'
@@ -300,7 +299,7 @@ const getIcon = (itemName) => {
 }
 
 const displayedHomeDirection = computed(() => {
-  const direction = listing.homeDirection
+  const direction = listing?.homeDirection
   if (!direction) {
     return ''
   }
@@ -312,7 +311,7 @@ const displayedHomeDirection = computed(() => {
 })
 
 const categorizedFacilities = computed(() => {
-  if (!listing.facilities || !Array.isArray(listing.facilities)) {
+  if (!listing?.facilities || !Array.isArray(listing?.facilities)) {
     return {}
   }
   return listing.facilities.reduce((acc, item) => {

--- a/src/pages/homes/HomeDetailsPage.vue
+++ b/src/pages/homes/HomeDetailsPage.vue
@@ -1,13 +1,11 @@
 <template>
   <div class="max-w-4xl mx-auto p-6">
-    <!-- 이미지 갤러리 -->
-    <ImageGallery :images="images" />
+    <ImageGallery v-if="images.length > 0" :images="images" />
 
     <div v-if="listing" class="mt-6 space-y-10">
       <ListingBasicInfo :listing="listing" />
       <RoomDetails :listing="listing" />
 
-      <!-- 매물 위치 지도 -->
       <TravelMap
         :title="listing.residenceType + ' 매물 위치'"
         :address="listing.addr1 + ' ' + listing.addr2"
@@ -17,6 +15,9 @@
       <div class="w-full flex gap-4">
         <BaseButton class="w-full" variant="primary" size="lg" @click="goChat">
           연락하기
+        </BaseButton>
+        <BaseButton class="w-full" variant="secondary" size="lg" @click="goRiskCheck">
+          <span class="w-full">사기위험도 분석</span>
         </BaseButton>
       </div>
     </div>
@@ -49,8 +50,10 @@ onMounted(async () => {
     const data = await fetchListingById(id)
     console.log('✅ 매물 상세 API 응답:', data)
 
-    listing.value = data
-    images.value = data.imageUrls || []
+    if (data) {
+      listing.value = data
+      images.value = data.imageUrls || []
+    }
   } catch (err) {
     console.error('매물 조회 실패:', err)
   }
@@ -58,5 +61,9 @@ onMounted(async () => {
 
 function goChat() {
   router.push('/chat')
+}
+
+function goRiskCheck() {
+  router.push('/risk-check')
 }
 </script>

--- a/src/pages/homes/HomeListPage.vue
+++ b/src/pages/homes/HomeListPage.vue
@@ -1,10 +1,8 @@
 <template>
   <div class="flex">
-    <!-- 필터 컴포넌트 -->
     <FilterSidebar @filter-change="onFilterChange" />
 
     <main class="flex-1 p-6 relative">
-      <!-- 매물 등록 버튼 -->
       <button
         class="absolute top-4 right-4 bg-yellow-primary hover:bg-yellow-500 text-white font-bold py-2 px-4 rounded z-10"
         type="button"
@@ -16,14 +14,15 @@
       <h1 class="text-2xl font-bold mb-4">전체 매물</h1>
 
       <div class="mb-4 text-lg font-bold">
-        {{ selectedGu }} 외 {{ otherCount }} 지역
-        <span class="text-yellow-primary">{{ filteredListings.length }}</span
+        {{ selectedGu }}
+        <span v-if="otherCount > 0">외 {{ otherCount }} 지역</span>
+        <span class="text-yellow-primary">{{ listings.length }}</span
         >개 매물
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <ListingCard
-          v-for="listing in filteredListings"
+          v-for="listing in listings"
           :key="listing.homeId"
           :listing="listing"
           @click="goDetailPage(listing.homeId)"
@@ -46,67 +45,38 @@ const router = useRouter()
 // API에서 받아온 매물 리스트 저장
 const listings = ref([])
 
-// 필터 상태 초기값
+// 필터 상태 초기값 (기존과 동일)
 const filters = ref({
   city: '전체',
   district: '전체',
-  dealType: '전체',
-  depositRange: 100000000, // 충분히 큰 기본값으로 변경
-  monthlyRange: 1000000,
-  sizeRange: 1000,
-  directions: [],
-  floors: [],
+  houseType: '전체',
+  dealType: '월세',
+  depositRange: 500,
+  monthlyRange: 50,
+  leaseRange: 10000,
+  area: 30,
+  direction: null,
+  floor: null,
   conditions: [],
-})
-
-// 필터된 매물 리스트 계산 (프론트단 필터링)
-const filteredListings = computed(() => {
-  return listings.value.filter((listing) => {
-    if (filters.value.city !== '전체' && listing.gu !== filters.value.city) return false
-    if (filters.value.district !== '전체' && listing.dong !== filters.value.district) return false
-    if (filters.value.dealType !== '전체' && listing.type !== filters.value.dealType) return false
-
-    if (filters.value.dealType === '월세') {
-      if ((listing.deposit ?? 0) > filters.value.depositRange) return false
-      if ((listing.monthly ?? 0) > filters.value.monthlyRange) return false
-    }
-
-    if ((listing.area ?? 0) > filters.value.sizeRange) return false
-
-    if (
-      filters.value.directions.length > 0 &&
-      !filters.value.directions.includes(listing.direction)
-    )
-      return false
-
-    if (filters.value.floors.length > 0 && !filters.value.floors.includes(listing.floorRange))
-      return false
-
-    if (
-      filters.value.conditions.length > 0 &&
-      !filters.value.conditions.every((cond) => listing.conditions?.includes(cond))
-    )
-      return false
-
-    return true
-  })
 })
 
 // 선택된 지역 텍스트
 const selectedGu = computed(() => {
-  return filters.value.district !== '전체' ? filters.value.district : filters.value.city
+  return filters.value.district !== '전체' && filters.value.district !== undefined
+    ? filters.value.district
+    : filters.value.city
 })
 
 // 나머지 지역 개수
 const otherCount = computed(() => {
-  const uniqueGus = new Set(filteredListings.value.map((listing) => listing.gu))
+  const uniqueGus = new Set(listings.value.map((listing) => listing.addr1))
   return uniqueGus.size > 1 ? uniqueGus.size - 1 : 0
 })
 
 // 필터 변경 이벤트 핸들러
 function onFilterChange(newFilters) {
   filters.value = { ...newFilters }
-  loadListings() // 필터 변경 시 API 다시 호출 (필터 서버반영 시 필요)
+  loadListings() // 필터가 변경될 때마다 API를 다시 호출
 }
 
 // 매물 등록 페이지 이동
@@ -119,21 +89,27 @@ function goDetailPage(id) {
   router.push(`/homes/${id}`)
 }
 
-// 실제 API 호출, 필터 조건 API 전송 가능하도록 params 확장 가능
+// 실제 API 호출, 필터 조건을 API 전송
 async function loadListings() {
   try {
     const params = {
-      // 페이지, 사이즈 등 페이징 파라미터 추가 가능
-      // page: 1,
-      // size: 10,
-      // 필터 조건을 API가 받도록 수정시 아래 주석 해제 후 사용
-      // city: filters.value.city !== '전체' ? filters.value.city : undefined,
-      // district: filters.value.district !== '전체' ? filters.value.district : undefined,
-      // dealType: filters.value.dealType !== '전체' ? filters.value.dealType : undefined,
-      // ...
+      // 필터 조건을 API가 받도록 수정
+      city: filters.value.city !== '전체' ? filters.value.city : undefined,
+      district: filters.value.district !== '전체' ? filters.value.district : undefined,
+      houseType: filters.value.houseType !== '전체' ? filters.value.houseType : undefined,
+      dealType: filters.value.dealType,
+      depositRange: filters.value.dealType === '월세' ? filters.value.depositRange : undefined,
+      monthlyRange: filters.value.dealType === '월세' ? filters.value.monthlyRange : undefined,
+      leaseRange: filters.value.dealType === '전세' ? filters.value.leaseRange : undefined,
+      area: Math.round(filters.value.area * 3.30578),
+      direction: filters.value.direction,
+      floor: filters.value.floor,
+      conditions:
+        filters.value.conditions.length > 0 ? filters.value.conditions.join(',') : undefined,
     }
-    listings.value = await fetchListings(params)
-    console.log(listings.value)
+    // API 호출 시 필터 파라미터 전달
+    const result = await fetchListings(params)
+    listings.value = result // API 응답으로 받은 데이터로 listings 업데이트
   } catch (err) {
     console.error('목록 조회 실패:', err)
   }


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #1

## 🔑 주요 변경사항

<!-- 내가 작업한 내용에 대해 작성해주세요! -->

- 매물 상세페이지 관리비, 시설정보 연동 

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 라벨을 등록했는가?
- [x] 리뷰어를 지정했는가?

## 📢 To Reviewers

<!-- 선택 사항 -->

## 📸 스크린샷 or 실행영상

## ↗️ 개선 사항

<!-- 선택 사항 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매물 상세 페이지에 "사기위험도 분석" 버튼이 추가되어, 클릭 시 리스크 체크 페이지로 이동할 수 있습니다.

* **버그 수정**
  * 이미지가 없는 경우 "이미지 없음"이라는 플레이스홀더가 표시되어 빈 이미지 영역 대신 안내 메시지가 노출됩니다.

* **기능 개선**
  * 매물 상세의 방향 정보가 한글로 표시됩니다.
  * 관리비 포함 항목, 내부/보안/편의시설 등이 동적으로 분류되어 아이콘과 함께 표시됩니다.
  * 필터 사이드바에서 필터 변경 시 변환 없이 원본 데이터가 바로 반영됩니다.
  * 매물 목록에서 이미지가 없을 때 플레이스홀더가 표시됩니다.
  * 매물 리스트 필터링이 프론트엔드에서 API 기반으로 변경되어 더 정확한 결과를 제공합니다.

* **스타일**
  * 필수 입력 항목에 빨간색 별표(*)로 필수 표시가 추가되었습니다.
  * 상세 설명 입력란에서 필수 표시가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->